### PR TITLE
Add Project Status Report procedure; wire into PM role (terminal-only)

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,5 +1,3 @@
-<!-- Plain-language PR template for CORA. Keep it scannable and link paths. -->
-
 ## Summary
 Explain what changed in simple terms and why it matters.
 
@@ -24,4 +22,3 @@ Explain what changed in simple terms and why it matters.
 
 ## Links
 - Project or task paths that track this work.
-

--- a/context/project-tasks/cora/project-status-report.md
+++ b/context/project-tasks/cora/project-status-report.md
@@ -2,10 +2,10 @@
 kind: task
 title: Add Project Status Report Procedure
 project: cora
-status: done
-git_status: merged
+status: doing
+git_status: pr_open
 branch: feature/project-status-report
-pr_url: 
+pr_url: https://github.com/joshua-lossner/cora/pull/2
 updated: 2025-10-04
 tags: [projects, tasks, report]
 depends_on: [establish-branching-strategy]
@@ -27,4 +27,3 @@ Create a read-only procedure that prints a terminal report of all projects and t
 ## Links
 - `procedures/project-management/report_status.md:1`
 - `context/roles/project-manager.md:1`
-

--- a/context/project-tasks/cora/project-status-report.md
+++ b/context/project-tasks/cora/project-status-report.md
@@ -1,0 +1,30 @@
+---
+kind: task
+title: Add Project Status Report Procedure
+project: cora
+status: done
+git_status: merged
+branch: feature/project-status-report
+pr_url: 
+updated: 2025-10-04
+tags: [projects, tasks, report]
+depends_on: [establish-branching-strategy]
+---
+
+# Task — Add Project Status Report Procedure
+
+## Purpose
+Create a read-only procedure that prints a terminal report of all projects and their task statuses (including git fields), to aid daily reviews.
+
+## Steps
+1) Add `procedures/project-management/report_status.md:1` with Operator Prompt.
+2) Add to Project Manager role shortlist.
+3) Validate by running a dry read of `context/projects/*.md` and `context/project-tasks/*/*.md`.
+
+## Acceptance
+- Procedure exists; Project Manager loads it; output shape is human-scannable.
+
+## Links
+- `procedures/project-management/report_status.md:1`
+- `context/roles/project-manager.md:1`
+

--- a/context/projects/cora.md
+++ b/context/projects/cora.md
@@ -25,6 +25,8 @@ Evolve the CORA trunk (canon content, rails, roles, and procedures) and keep onb
 ## PRs (Log)
 - 2025-10-04 — feature/roles-procedures-forest — Expand roles, procedures, and forest; onboarding polish — Status: Merged — PR: https://github.com/joshua-lossner/cora/pull/1
   - Summary: Adds a full set of role manifests and supporting procedures; simplifies the forest to a single group manifest; seeds downstream projects; improves README/AGENTS onboarding; and links the validator and example session.
+- 2025-10-04 — feature/project-status-report — Add Project Status Report procedure; wire into PM role (terminal-only) — Status: PR Open — PR: https://github.com/joshua-lossner/cora/pull/2
+  - Summary: Adds a read-only status report procedure to print projects and tasks in terminal; wired into PM role and tracked as a task.
 
 ## Next Small Moves
 - Open PR for current branch and log it above.

--- a/context/roles/project-manager.md
+++ b/context/roles/project-manager.md
@@ -25,6 +25,7 @@ Coordinate multi-session work, keep projects moving with small, verifiable steps
    - `procedures/project-management/triage_backlog.md:1`
    - `procedures/project-management/log_decision.md:1`
    - `procedures/project-management/handoff.md:1`
+   - `procedures/project-management/report_status.md:1`
 6) Rails/References — `context/documentation/cora/knowledge-tree.md:1`
 7) Git (shortlist)
    - `procedures/git/branching_strategy.md:1`

--- a/context/tools/github-cli.md
+++ b/context/tools/github-cli.md
@@ -17,8 +17,10 @@ Install & Auth
 - Authenticate: `gh auth login` (choose GitHub.com, HTTPS, and follow prompts). For CI/non-interactive, set `GH_TOKEN`.
 
 Common Commands
-- Open PR (from your branch): `gh pr create --base main --fill`  
-  - Flags: `--title`, `--body`, or `--fill` (uses template)
+- Open PR (from your branch) with template only (recommended):  
+  - `gh pr create --base main --title "<title>" --body-file .github/pull_request_template.md`
+- Open PR using auto-fill (may include commit messages):  
+  - `gh pr create --base main --fill`
 - View PR: `gh pr view --web` (opens in browser)
 - Check status: `gh pr status`
 - Assign reviewers: `gh pr edit --add-reviewer <user>`
@@ -26,10 +28,9 @@ Common Commands
 Flow (with our procedures)
 1) Start branch: `procedures/git/start_feature.md:1`
 2) Push branch: `git push -u origin <branch>`
-3) Create PR: `gh pr create --base main --title "<title>" --body-file .github/pull_request_template.md` (or `--fill`)
+3) Create PR: `gh pr create --base main --title "<title>" --body-file .github/pull_request_template.md` (preferred) or `--fill` (may include commit text)
 4) Update project/task per `procedures/git/open_pull_request.md:1`
 
 Notes
 - Keep PR language plain for non-technical readers; link repo paths.
 - Use `--fill` to auto-populate title/body from the default template.
-

--- a/procedures/git/open_pull_request.md
+++ b/procedures/git/open_pull_request.md
@@ -33,6 +33,10 @@ Tools (optional)
   - Add reviewers: `gh pr edit --add-reviewer <user>`
   - Edit an existing PR (e.g., add the plain-language body): `gh pr edit <number> --title "<title>" --body-file <path-to-body.md>`
 
+Notes
+- If the web UI pre-fills commit messages above the template, delete those lines and keep only the template sections (Summary, What Changed, Checks Run, Impact, Reviewers, Links).
+- For a clean body without commit messages, prefer `gh pr create --body-file .github/pull_request_template.md` instead of `--fill`.
+
 PR Template (copy-paste)
 Title
 - Short, plain-language summary (e.g., “Add roles and tidy forest index”)

--- a/procedures/project-management/report_status.md
+++ b/procedures/project-management/report_status.md
@@ -1,0 +1,46 @@
+---
+kind: procedure
+title: Project Status — Report Projects and Tasks
+intent: List all projects and their task statuses, including git fields, as a terminal-only report
+status: active
+updated: 2025-10-04
+tags: [projects, tasks, report]
+---
+
+# Procedure — Project Status Report (Terminal)
+
+Purpose
+- Provide a quick, non-editing overview of current projects and tasks, suitable for pasting into the terminal or a chat session.
+
+Scope
+- Reads files only. Does not edit content.
+- Sources: `context/projects/*.md`, `context/project-tasks/<project>/*.md`.
+
+Inputs
+- None (defaults to all projects). Optionally a project slug to narrow focus.
+
+Expected
+- A concise, grouped report: project title/status/updated, PR log entries (if present), and a list of tasks with status, updated, and git fields.
+
+Steps
+1) Projects — list `context/projects/*.md`; for each, parse frontmatter: `title`, `status`, `updated`.
+2) PR Log — if a project file includes a “PRs (Log)” section, capture each line as-is.
+3) Tasks — if `context/project-tasks/<slug>/` exists, list tasks; parse frontmatter: `title`, `status`, `updated`, and optional `git_status`, `branch`, `pr_url`.
+4) Output — print a terminal report grouped by project:
+   - Project: <Title> (status, updated)
+   - PRs (Log): bullet each entry
+   - Tasks: `- [status] Title — updated: <date> — git: <git_status> <branch> <pr_url>` (omit missing fields)
+5) Do not write files; if errors occur, output short notes.
+
+Operator Prompt
+"""
+You are reporting CORA project status to the terminal.
+1) List projects from `context/projects/*.md`; print: Title (status, updated).
+2) For each project, if a “PRs (Log)” section exists, print each PR line.
+3) If `context/project-tasks/<project>/` exists, list each task as: `- [<status>] <title> — updated: <date> — git: <git_status> <branch> <pr_url>` (only include git fields that are present).
+4) Keep output concise and grouped by project. Do not modify files.
+"""
+
+Notes
+- Designed for human scanning; adjust verbosity by omitting empty sections.
+


### PR DESCRIPTION
## Summary
Adds a read-only Project Status Report procedure that prints a terminal summary of projects and tasks (including git fields). Wires it into the Project Manager role and records a tracking task.

## What Changed
- Procedures: `procedures/project-management/report_status.md:1`
- Role: `context/roles/project-manager.md:1` (added to shortlist)
- Task: `context/project-tasks/cora/project-status-report.md:1`

## Checks Run
- Doc-only; no downstream release.

## Impact
- Faster daily status reviews; no content edits.

## Reviewers
- Project Manager, QA/Release Manager

## Links
- `context/projects/cora.md:1`
