### PR TITLE
Add project: coherenceism.project — UFC Project Viewer

### DIFF
--- a/context/projects/COHERENCE.md
+++ b/context/projects/COHERENCE.md
@@ -21,6 +21,7 @@ Conventions
 Contents
 - `essay-series.md` — Multi‑essay series exploring Coherenceism in practice.
 - `cora.md` — Trunk evolution and operations (roles, procedures, rails)
+- `coherenceism-project.md` — UFC project/task/workflow visualizer app
 
 Notes
 - Archive by renaming `status: archived` when a project completes; keep the file for provenance.

--- a/context/projects/coherenceism-project.md
+++ b/context/projects/coherenceism-project.md
@@ -1,0 +1,37 @@
+---
+kind: project
+title: coherenceism.project — UFC Project Viewer
+status: active
+updated: 2025-10-04
+tags: [projects, ui, ufc]
+---
+
+# coherenceism.project — UFC Project Viewer
+
+## Purpose
+Build a read‑only, UFC‑aware app that visualizes CORA projects, tasks (with git fields), PRs log, and links to roles/procedures/workflows — keeping you and your agents (Ivy, S’Vektor) in sync at a glance.
+
+## Scope
+- Reads from a local CORA submodule (no canon edits).
+- Dashboards: projects list, tasks by project with status/updated/git fields, PRs log.
+- Filters: status (todo/doing/blocked/done) and git_status (none/in_branch/pr_open/merged).
+- Design: adopt `coherenceism.design` tokens/CSS for visual coherence.
+- Optional: show PR titles/status via GitHub when configured.
+
+## Dependencies
+- CORA as a read‑only submodule (`cora/`).
+- (Later) `coherenceism.design` tokens.
+- (Optional) GitHub token for PR metadata.
+
+## Tasks (Summary)
+- [ ] context/project-tasks/coherenceism-project/init-repo-and-submodule.md:1
+- [ ] context/project-tasks/coherenceism-project/parse-projects-and-tasks.md:1
+- [ ] context/project-tasks/coherenceism-project/ui-scaffold-and-filters.md:1
+- [ ] context/project-tasks/coherenceism-project/pr-links-and-a11y.md:1
+
+## PRs (Log)
+- Add entries here when opening PRs (date, branch, title, summary, status, link).
+
+## Notes
+- Downstream path: `~/Projects/coherenceism.project/` (code lives there; this file tracks intent/plan in CORA).
+


### PR DESCRIPTION
## Summary
Adds a new project file for the downstream coherenceism.project app (UFC‑aware project/task/workflow viewer). Tracks purpose, scope, dependencies, task checklist, and notes the downstream repo location.

## What Changed
- Project: `context/projects/coherenceism-project.md:1`
- Projects index: `context/projects/COHERENCE.md:1`

## Checks Run
- Doc-only; no downstream release.

## Impact
- Establishes a single place in CORA to coordinate the downstream project’s plan.

## Reviewers
- Product Lead, Project Manager

## Links
- Downstream path: `~/Projects/coherenceism.project/`
