### PR TITLE
Add coherenceism.project tasks and CORA Suno prompt tasks

### DIFF
--- a/context/project-tasks/coherenceism-project/init-repo-and-submodule.md
+++ b/context/project-tasks/coherenceism-project/init-repo-and-submodule.md
@@ -1,0 +1,42 @@
+---
+kind: task
+title: Initialize Downstream Repo and Add CORA Submodule
+project: coherenceism-project
+status: todo
+git_status: none
+branch: 
+pr_url: 
+updated: 2025-10-04
+tags: [setup, git, submodule, integration]
+depends_on: []
+---
+
+# Task — Initialize Downstream Repo and Add CORA Submodule
+
+## Purpose
+Create the downstream repository and add CORA as a read-only git submodule at `cora/`, documenting the integration so subsequent tasks can parse UFC content safely.
+
+## Steps
+1) Create downstream repo at `~/Projects/coherenceism.project/` (or chosen path) and initialize git.
+2) Add CORA as submodule under `cora/` via `procedures/site/add_cora_submodule.md:1`.
+3) Commit a short `docs/integration.md` noting which views will read from which `cora/` paths.
+4) Start a feature branch for this setup via `procedures/git/start_feature.md:1`.
+5) Open a PR when ready via `procedures/git/open_pull_request.md:1` and update this task’s git fields.
+
+## Acceptance
+- Downstream repo exists with `cora/` submodule initialized and documented.
+- Branch opened; PR created or planned; git fields updated here when opened.
+
+## Roles
+- DevOps/SRE — `context/roles/devops-sre.md:1`
+- Backend Engineer — `context/roles/backend-engineer.md:1`
+- Project Manager — `context/roles/project-manager.md:1`
+
+## Links
+- `procedures/site/add_cora_submodule.md:1`
+- `procedures/git/start_feature.md:1`
+- `procedures/git/open_pull_request.md:1`
+
+## Notes
+- Keep CORA read-only; do not modify canon from the downstream app repo.
+

--- a/context/project-tasks/coherenceism-project/parse-projects-and-tasks.md
+++ b/context/project-tasks/coherenceism-project/parse-projects-and-tasks.md
@@ -1,0 +1,47 @@
+---
+kind: task
+title: Parse CORA Projects and Tasks (UFC Adapter)
+project: coherenceism-project
+status: todo
+git_status: none
+branch: 
+pr_url: 
+updated: 2025-10-04
+tags: [backend, parser, ufc]
+depends_on: [init-repo-and-submodule]
+---
+
+# Task — Parse CORA Projects and Tasks (UFC Adapter)
+
+## Purpose
+Implement a read-only UFC adapter that scans `cora/context/projects/*.md` and `cora/context/project-tasks/*/*.md`, extracting frontmatter and key sections for the viewer app.
+
+## Steps
+1) Define data models for Project and Task (frontmatter + links to sections):
+   - Project: title, status, updated, tags; tasks summary paths; PR log entries.
+   - Task: project, status, updated, git_status, branch, pr_url, depends_on, tags.
+2) Implement readers:
+   - Parse YAML frontmatter and capture section anchors (`#`, `##`).
+   - Map task slugs to file paths and resolve `depends_on` references.
+3) Provide a simple in-memory index (filterable by project/status/git_status).
+4) Add a short readme in downstream repo describing the adapter inputs/outputs.
+5) Start a feature branch; open a PR when ready and update git fields here.
+
+## Acceptance
+- Running the adapter lists all projects and tasks with accurate metadata.
+- Filters by status and git_status work in memory.
+- No writes to CORA; read-only file access only.
+
+## Roles
+- Backend Engineer — `context/roles/backend-engineer.md:1`
+- Content Librarian (optional validation) — `context/roles/content-librarian.md:1`
+- Project Manager — `context/roles/project-manager.md:1`
+
+## Links
+- `context/documentation/cora/knowledge-tree.md:1`
+- `procedures/api/expose_content_api.md:1` (reference-only; keep this adapter file-first)
+- `procedures/git/start_feature.md:1`, `procedures/git/open_pull_request.md:1`
+
+## Notes
+- Keep the adapter agnostic: return plain objects; defer rendering to UI.
+

--- a/context/project-tasks/coherenceism-project/pr-links-and-a11y.md
+++ b/context/project-tasks/coherenceism-project/pr-links-and-a11y.md
@@ -1,0 +1,44 @@
+---
+kind: task
+title: PR Links, GitHub Integration (Optional), and A11y Pass
+project: coherenceism-project
+status: todo
+git_status: none
+branch: 
+pr_url: 
+updated: 2025-10-04
+tags: [integrations, github, accessibility]
+depends_on: [ui-scaffold-and-filters]
+---
+
+# Task — PR Links, GitHub Integration (Optional), and A11y Pass
+
+## Purpose
+Surface PR links/status for tasks in the UI. Optionally enrich with GitHub PR titles/status when a token is configured. Run an accessibility pass across the app.
+
+## Steps
+1) Display PR links from task frontmatter (`pr_url`, `branch`, `git_status`).
+2) Optional GitHub integration:
+   - If `GITHUB_TOKEN` provided, fetch PR title/status by URL or branch and render read-only.
+   - Keep integration purely optional; feature-gate by env var.
+3) Run `procedures/accessibility/a11y_audit.md:1` and fix critical issues.
+4) Start a branch; open PR; update git fields here.
+
+## Acceptance
+- Tasks show PR link (when present) and a human label for `git_status`.
+- With token present, PR title/status appears; without, UI still works.
+- A11y audit results addressed for critical issues.
+
+## Roles
+- Integrations Engineer — `context/roles/integrations-engineer.md:1`
+- Accessibility Lead — `context/roles/accessibility-lead.md:1`
+- Frontend Engineer — `context/roles/frontend-engineer.md:1`
+- Project Manager — `context/roles/project-manager.md:1`
+
+## Links
+- `procedures/accessibility/a11y_audit.md:1`
+- `procedures/git/start_feature.md:1`, `procedures/git/open_pull_request.md:1`
+
+## Notes
+- Avoid write operations to GitHub; fetch only.
+

--- a/context/project-tasks/coherenceism-project/ui-scaffold-and-filters.md
+++ b/context/project-tasks/coherenceism-project/ui-scaffold-and-filters.md
@@ -1,0 +1,46 @@
+---
+kind: task
+title: UI Scaffold and Filters
+project: coherenceism-project
+status: todo
+git_status: none
+branch: 
+pr_url: 
+updated: 2025-10-04
+tags: [frontend, ui, filters, design]
+depends_on: [parse-projects-and-tasks]
+---
+
+# Task — UI Scaffold and Filters
+
+## Purpose
+Stand up a minimal, accessible UI that lists projects and tasks using the UFC adapter, with filters for `status` and `git_status`.
+
+## Steps
+1) Draft a UX Flow Brief via `procedures/design/ux_flow_brief.md:1` (views: projects list, project detail with tasks, PRs log).
+2) Scaffold UI components (read-only):
+   - Projects list with status chip and updated date.
+   - Project detail: tasks table (status, updated, git_status, branch, PR link).
+   - Filters: status (todo/doing/blocked/done), git_status (none/in_branch/pr_open/merged).
+3) Apply baseline design tokens from `coherenceism.design` when available; otherwise keep semantic HTML and system fonts.
+4) Keyboard and screen reader checks for core flows (list focus order, filter activation, link labels).
+5) Start a branch; open PR and update git fields when ready.
+
+## Acceptance
+- UI renders projects and tasks from the adapter with working filters.
+- Basic a11y checks pass (focus order, labels, status contrast).
+
+## Roles
+- Frontend Engineer — `context/roles/frontend-engineer.md:1`
+- UX Designer — `context/roles/ux-designer.md:1`
+- Design System Steward — `context/roles/design-system-steward.md:1`
+- Project Manager — `context/roles/project-manager.md:1`
+
+## Links
+- `procedures/design/ux_flow_brief.md:1`
+- `procedures/accessibility/a11y_audit.md:1`
+- `procedures/git/start_feature.md:1`, `procedures/git/open_pull_request.md:1`
+
+## Notes
+- Keep components simple and data-first; no mutations.
+

--- a/context/project-tasks/cora/create-suno-prompt-procedures.md
+++ b/context/project-tasks/cora/create-suno-prompt-procedures.md
@@ -1,0 +1,43 @@
+---
+kind: task
+title: Author Procedures — Suno Prompt Recipes
+project: cora
+status: todo
+git_status: none
+branch: 
+pr_url: 
+updated: 2025-10-04
+tags: [procedures, prompts, media, suno]
+depends_on: [create-suno-prompt-workflow]
+---
+
+# Task — Author Procedures: Suno Prompt Recipes
+
+## Purpose
+Add concrete procedures that operators can run to compose, iterate, and refine Suno prompts. Keep them vendor-neutral and reusable.
+
+## Steps
+1) Create Quickstart procedure at `procedures/media/suno_prompt_quickstart.md:1` with a minimal prompt template and a short run-through.
+2) Create Detailed Recipe at `procedures/media/suno_prompt_recipe.md:1` covering: genre/style, BPM/energy, mood adjectives, instrumentation, vocals, structure, production/mix notes, optional references (style-level), negative constraints; include examples.
+3) Create Iteration Loop at `procedures/media/suno_prompt_iteration.md:1` (vary seeds/settings, compare outputs, keep best-of, note deltas).
+4) Update `procedures/COHERENCE.md:1` to index the above under Media.
+5) (Optional) Add tool note at `context/tools/suno.md:1` (capabilities, safe use, dos/don’ts).
+
+## Acceptance
+- Three procedures exist (Quickstart, Recipe, Iteration) with CORA procedure frontmatter and clear steps.
+- Indexed in `procedures/COHERENCE.md` with short summaries.
+- Examples included; language is vendor-neutral and policy-safe.
+
+## Roles
+- Writer/Editor — `context/roles/writer-editor.md:1`
+- Media Producer — `context/roles/media-producer.md:1`
+- Content Librarian — `context/roles/content-librarian.md:1`
+- Project Manager — `context/roles/project-manager.md:1`
+
+## Links
+- `procedures/COHERENCE.md:1`
+- `procedures/media/produce_audio_essay.md:1`
+
+## Notes
+- Avoid copyrighted lyrics and direct song replication; keep prompts descriptive at the style/mood level.
+

--- a/context/project-tasks/cora/create-suno-prompt-workflow.md
+++ b/context/project-tasks/cora/create-suno-prompt-workflow.md
@@ -1,0 +1,42 @@
+---
+kind: task
+title: Create Workflow — Suno Prompting
+project: cora
+status: todo
+git_status: none
+branch: 
+pr_url: 
+updated: 2025-10-04
+tags: [workflow, prompts, media, suno]
+depends_on: []
+---
+
+# Task — Create Workflow: Suno Prompting
+
+## Purpose
+Define a reusable workflow for crafting effective prompts for Suno (AI music), including inputs, steps, iteration loop, and examples — vendor-neutral and adaptable.
+
+## Steps
+1) Draft workflow doc at `workflows/suno_prompts.md:1` following CORA workflow conventions (frontmatter, Purpose, Inputs, Steps, Expected, Operator Prompt).
+2) Include a compact "Operator Prompt" that guides an agent through: goal/brief, style/genre, tempo/BPM, mood adjectives, instrumentation, vocals (on/off, style), structure (intro/verse/chorus/bridge/outro), references (optional, style-level only), production/mix notes, negative constraints.
+3) Provide 2–3 example prompts (different genres) and note how to iterate and compare outputs.
+4) Link the workflow in `workflows/COHERENCE.md:1` under an appropriate section.
+5) Save changes and update this task status and `updated` when complete.
+
+## Acceptance
+- `workflows/suno_prompts.md` exists with frontmatter and an Operator Prompt.
+- Includes clear inputs, steps, iteration loop, and at least 2 example prompts.
+- Indexed in `workflows/COHERENCE.md`.
+
+## Roles
+- Writer/Editor — `context/roles/writer-editor.md:1`
+- Media Producer — `context/roles/media-producer.md:1`
+- Project Manager — `context/roles/project-manager.md:1`
+
+## Links
+- `workflows/COHERENCE.md:1`
+- `procedures/writing/prepare_input.md:1`
+
+## Notes
+- Keep prompts original; avoid copyrighted lyrics. Reference styles at a high level; do not copy specific compositions.
+

--- a/context/project-tasks/cora/open-session-branch-and-pr.md
+++ b/context/project-tasks/cora/open-session-branch-and-pr.md
@@ -1,0 +1,47 @@
+---
+kind: task
+title: Open Session Branch and PR
+project: cora
+status: todo
+git_status: none
+branch: 
+pr_url: 
+updated: 2025-10-04
+tags: [git, pr, session, pm]
+depends_on: [establish-branching-strategy]
+---
+
+# Task — Open Session Branch and PR
+
+## Purpose
+Create a short-lived feature branch for today’s CORA content changes and open a PR. Scope for this session: create `coherenceism.project` and its project tasks; add CORA project tasks for creating a Suno workflow and procedures. Log the PR on the CORA project page and update this task’s git fields for traceability.
+
+## Steps
+1) Choose a branch name (example): `feature/coherenceism-project-and-suno-tasks`.
+2) Start the branch using `procedures/git/start_feature.md:1`.
+3) Stage and commit today’s content changes (new tasks and project updates) with concise messages referencing file paths.
+4) Push the branch and open a PR using `procedures/git/open_pull_request.md:1` (or GitHub CLI if configured).
+   - Proposed PR title: "Add coherenceism.project tasks and CORA Suno prompt tasks".
+   - PR body summary bullets (suggested):
+     - Add project tasks for `coherenceism.project` (init, UFC adapter, UI scaffold, PR links/a11y).
+     - Add CORA tasks for Suno prompting (workflow + procedures).
+     - Update `context/projects/cora.md` task summary.
+5) Update `context/projects/cora.md:1` under “PRs (Log)” with date, branch, title, summary, status, and PR link.
+6) Update this task frontmatter: set `git_status: pr_open`, fill `branch` and `pr_url`, and refresh `updated`.
+
+## Acceptance
+- Feature branch exists and PR is open to `main` with the title reflecting this session’s scope.
+- CORA project page shows a PR entry under “PRs (Log)”.
+- This task frontmatter updated with `git_status: pr_open`, `branch`, and `pr_url`.
+
+## Roles
+- Project Manager — `context/roles/project-manager.md:1`
+- QA/Release Manager — `context/roles/qa-release-manager.md:1`
+
+## Links
+- `procedures/git/start_feature.md:1`
+- `procedures/git/open_pull_request.md:1`
+- `context/projects/cora.md:1`
+
+## Notes
+- Keep scope to today’s content changes only; if work grows, split into additional branches/PRs.

--- a/context/projects/coherenceism-project.md
+++ b/context/projects/coherenceism-project.md
@@ -35,3 +35,7 @@ Build a read‑only, UFC‑aware app that visualizes CORA projects, tasks (with 
 ## Notes
 - Downstream path: `~/Projects/coherenceism.project/` (code lives there; this file tracks intent/plan in CORA).
 
+## Next Small Moves
+- Initialize downstream repo and add CORA submodule — `context/project-tasks/coherenceism-project/init-repo-and-submodule.md:1`
+- Implement UFC adapter to parse projects and tasks — `context/project-tasks/coherenceism-project/parse-projects-and-tasks.md:1`
+- Draft UX brief and scaffold UI with filters — `context/project-tasks/coherenceism-project/ui-scaffold-and-filters.md:1`

--- a/context/projects/cora.md
+++ b/context/projects/cora.md
@@ -21,6 +21,9 @@ Evolve the CORA trunk (canon content, rails, roles, and procedures) and keep onb
 - [ ] context/project-tasks/cora/establish-branching-strategy.md:1
 - [ ] context/project-tasks/cora/roles-procedures-forest.md:1
 - [ ] context/project-tasks/cora/track-prs.md:1
+- [ ] context/project-tasks/cora/create-suno-prompt-workflow.md:1
+- [ ] context/project-tasks/cora/create-suno-prompt-procedures.md:1
+- [ ] context/project-tasks/cora/open-session-branch-and-pr.md:1
 
 ## PRs (Log)
 - 2025-10-04 — feature/roles-procedures-forest — Expand roles, procedures, and forest; onboarding polish — Status: Merged — PR: https://github.com/joshua-lossner/cora/pull/1


### PR DESCRIPTION
Summary
- Add project tasks for coherenceism.project and CORA Suno prompting.

What Changed
- context/project-tasks/coherenceism-project/init-repo-and-submodule.md
- context/project-tasks/coherenceism-project/parse-projects-and-tasks.md
- context/project-tasks/coherenceism-project/ui-scaffold-and-filters.md
- context/project-tasks/coherenceism-project/pr-links-and-a11y.md
- context/project-tasks/cora/create-suno-prompt-workflow.md
- context/project-tasks/cora/create-suno-prompt-procedures.md
- context/project-tasks/cora/open-session-branch-and-pr.md
- context/projects/coherenceism-project.md
- context/projects/cora.md

Checks Run
- Content only; frontmatter and links checked locally.

Impact
- Clear tasks for coherenceism.project; CORA tasks for Suno prompting.

Links
- context/projects/coherenceism-project.md:1
- context/projects/cora.md:1