### PR TITLE
Add write-through PR API tasks and supporting procedures for coherenceism.project

### DIFF
--- a/context/project-tasks/coherenceism-project/design-write-through-pr-api.md
+++ b/context/project-tasks/coherenceism-project/design-write-through-pr-api.md
@@ -1,0 +1,46 @@
+---
+kind: task
+title: Design Write-through PR API for CORA Updates
+project: coherenceism-project
+status: todo
+git_status: none
+branch: 
+pr_url: 
+updated: 2025-10-04
+tags: [api, spec, github-app, safety]
+depends_on: []
+---
+
+# Task — Design Write-through PR API for CORA Updates
+
+## Purpose
+Define an HTTP API that converts GUI actions in coherenceism.project into CORA pull requests, keeping CORA canonical and fully auditable.
+
+## Steps
+1) Specify endpoints and payloads (minimal set):
+   - `POST /cora/projects/{project}/tasks/{task}/state` → flip `status`, update `updated`, optional git fields.
+   - `POST /cora/projects/{project}/log` → append PR log entries.
+   - Path whitelist limited to `context/projects/` and `context/project-tasks/`.
+2) Auth model: GitHub App with restricted perms (contents:write, pull_requests:write).
+3) Conflict policy: optimistic (include base sha); on drift, rebase/update and re-run patch.
+4) Output: branch, PR URL; include preview of the computed diff.
+5) Document operator prompts and safety gates (no destructive edits; read-only preview first).
+
+## Acceptance
+- API spec doc exists with endpoints, payloads, responses, auth, and safety notes.
+- Examples include sample requests for marking a task done and logging a PR.
+
+## Roles
+- Product Lead — `context/roles/product-lead.md:1`
+- Backend Engineer — `context/roles/backend-engineer.md:1`
+- QA/Release Manager — `context/roles/qa-release-manager.md:1`
+- Project Manager — `context/roles/project-manager.md:1`
+
+## Links
+- `procedures/api/propose_cora_update_via_pr.md:1`
+- `context/documentation/cora/knowledge-tree.md:1`
+- `procedures/content/validate-content.md:1`
+
+## Notes
+- Default to read-only runtime; writes always go through PRs with human review.
+

--- a/context/project-tasks/coherenceism-project/implement-write-through-pr-api.md
+++ b/context/project-tasks/coherenceism-project/implement-write-through-pr-api.md
@@ -1,0 +1,43 @@
+---
+kind: task
+title: Implement Write-through PR API Service
+project: coherenceism-project
+status: todo
+git_status: none
+branch: 
+pr_url: 
+updated: 2025-10-04
+tags: [api, backend, github-app]
+depends_on: [design-write-through-pr-api]
+---
+
+# Task — Implement Write-through PR API Service
+
+## Purpose
+Build a small service that receives GUI updates, validates and patches CORA files, and opens PRs with clear messages and links.
+
+## Steps
+1) Create GitHub App and configure app permissions and secrets.
+2) Implement route handlers for designed endpoints; include:
+   - Path whitelist, frontmatter edits (status/updated/git fields), PR log appenders.
+   - Patch builder: compute minimal diff; include preview in response.
+3) Open a PR per request: branch name `feature/task-<slug>-<yyyymmdd>` with links to affected paths.
+4) Integrate content validator (`procedures/content/validate-content.md:1`) before commit.
+5) Return `{ pr_url, branch, base_sha }` to the client; log audit data.
+
+## Acceptance
+- Service runs locally; calling the API opens a PR in CORA with correct edits.
+- Validator passes; safety checks prevent edits outside allowed paths.
+
+## Roles
+- Backend Engineer — `context/roles/backend-engineer.md:1`
+- QA/Release Manager — `context/roles/qa-release-manager.md:1`
+- Project Manager — `context/roles/project-manager.md:1`
+
+## Links
+- `procedures/api/propose_cora_update_via_pr.md:1`
+- `procedures/git/open_pull_request.md:1`, `procedures/git/merge_to_main.md:1`
+
+## Notes
+- Keep implementation language/tooling minimal; portability > framework.
+

--- a/context/project-tasks/coherenceism-project/webhooks-sync-and-conflicts.md
+++ b/context/project-tasks/coherenceism-project/webhooks-sync-and-conflicts.md
@@ -1,0 +1,40 @@
+---
+kind: task
+title: Webhooks Sync and Conflict Handling
+project: coherenceism-project
+status: todo
+git_status: none
+branch: 
+pr_url: 
+updated: 2025-10-04
+tags: [webhooks, github, sync]
+depends_on: [wire-gui-actions-to-api]
+---
+
+# Task — Webhooks Sync and Conflict Handling
+
+## Purpose
+Keep the UI in sync with PR state (open/merged/closed) and handle update conflicts gracefully.
+
+## Steps
+1) Subscribe to GitHub webhooks (PR open/close/merge; checks complete).
+2) Update UI state for affected tasks/projects on webhook receipt.
+3) On conflict (drift vs. base SHA), prompt user to retry; API should rebase and reapply patch.
+4) Log failures with enough detail to reproduce locally.
+
+## Acceptance
+- PR state changes reflect in the UI within seconds.
+- Conflict cases present clear guidance and a retry path.
+
+## Roles
+- Integrations Engineer — `context/roles/integrations-engineer.md:1`
+- Backend Engineer — `context/roles/backend-engineer.md:1`
+- Project Manager — `context/roles/project-manager.md:1`
+
+## Links
+- `procedures/api/propose_cora_update_via_pr.md:1`
+- `procedures/git/merge_to_main.md:1`
+
+## Notes
+- Prefer idempotent handlers; ensure webhook verification and replay safety.
+

--- a/context/project-tasks/coherenceism-project/wire-gui-actions-to-api.md
+++ b/context/project-tasks/coherenceism-project/wire-gui-actions-to-api.md
@@ -1,0 +1,41 @@
+---
+kind: task
+title: Wire GUI Actions to Write-through API
+project: coherenceism-project
+status: todo
+git_status: none
+branch: 
+pr_url: 
+updated: 2025-10-04
+tags: [frontend, integration, api]
+depends_on: [implement-write-through-pr-api]
+---
+
+# Task — Wire GUI Actions to Write-through API
+
+## Purpose
+Connect UI actions (mark task done, edit fields) to the API, with a confirmation preview and PR link display.
+
+## Steps
+1) Add “Mark done” and “Edit task fields” actions on task rows.
+2) Confirmation dialog shows proposed changes and explains PR-based update.
+3) Call API; on success, render PR badge/link and optimistic state.
+4) Add a non-blocking toast with the PR URL; allow quick copy.
+5) Reconcile state via webhook or polling PR status.
+
+## Acceptance
+- From the UI, a user can complete a task and see the created PR link.
+- State reflects PR open/merged without page refresh.
+
+## Roles
+- Frontend Engineer — `context/roles/frontend-engineer.md:1`
+- Product Lead — `context/roles/product-lead.md:1`
+- Project Manager — `context/roles/project-manager.md:1`
+
+## Links
+- `procedures/api/propose_cora_update_via_pr.md:1`
+- `procedures/git/update_project_pr_log.md:1`
+
+## Notes
+- Keep all edits PR-gated; do not mutate CORA directly from the client.
+

--- a/context/projects/coherenceism-project.md
+++ b/context/projects/coherenceism-project.md
@@ -28,6 +28,10 @@ Build a read‑only, UFC‑aware app that visualizes CORA projects, tasks (with 
 - [ ] context/project-tasks/coherenceism-project/parse-projects-and-tasks.md:1
 - [ ] context/project-tasks/coherenceism-project/ui-scaffold-and-filters.md:1
 - [ ] context/project-tasks/coherenceism-project/pr-links-and-a11y.md:1
+- [ ] context/project-tasks/coherenceism-project/design-write-through-pr-api.md:1
+- [ ] context/project-tasks/coherenceism-project/implement-write-through-pr-api.md:1
+- [ ] context/project-tasks/coherenceism-project/wire-gui-actions-to-api.md:1
+- [ ] context/project-tasks/coherenceism-project/webhooks-sync-and-conflicts.md:1
 
 ## PRs (Log)
 - Add entries here when opening PRs (date, branch, title, summary, status, link).

--- a/context/projects/coherenceism-project.md
+++ b/context/projects/coherenceism-project.md
@@ -35,6 +35,8 @@ Build a read‑only, UFC‑aware app that visualizes CORA projects, tasks (with 
 
 ## PRs (Log)
 - Add entries here when opening PRs (date, branch, title, summary, status, link).
+- Add entries here when opening PRs (date, branch, title, summary, status, link).
+- 2025-10-04 — feature/write-through-api-tasks — Add write-through PR API tasks and procedures — Status: PR Open — PR: https://github.com/joshua-lossner/cora/pull/8
 
 ## Notes
 - Downstream path: `~/Projects/coherenceism.project/` (code lives there; this file tracks intent/plan in CORA).

--- a/procedures/api/propose_cora_update_via_pr.md
+++ b/procedures/api/propose_cora_update_via_pr.md
@@ -1,0 +1,37 @@
+---
+kind: procedure
+title: API — Propose CORA Update via PR
+intent: Turn a UI action into a CORA pull request with minimal, validated content edits
+status: active
+updated: 2025-10-04
+tags: [api, github-app, safety]
+---
+
+# Procedure — API: Propose CORA Update via PR
+
+Purpose
+- Provide a safe, auditable way for apps to update CORA by creating pull requests for limited, whitelisted edits.
+
+Inputs
+- Project slug, task slug (when applicable)
+- Desired changes (e.g., `status: done`, `updated: YYYY-MM-DD`, `git_status: pr_open|merged`, `branch`, `pr_url`)
+- Base commit SHA of CORA `main` used to generate the patch
+
+Steps
+1) Validate request fields; ensure target paths are inside `context/projects/` or `context/project-tasks/`.
+2) Read current files at the provided base SHA; compute minimal patch (frontmatter flips + PR log append).
+3) Run content validator (`procedures/content/validate-content.md:1`).
+4) Create branch `feature/task-<slug>-<yyyymmdd>` and commit patch with clear message (+ links to paths).
+5) Open a PR to `main` and return `{ pr_url, branch, base_sha }`.
+6) On PR open, ensure logs are updated per `procedures/git/open_pull_request.md:1`.
+
+Expected
+- A new branch and PR exist with only the intended edits; logs and task git fields are set.
+
+Safety
+- Enforce path whitelist; reject body fields outside allowed schema.
+- Require base SHA to reduce race conditions; handle drift with a new patch on latest.
+
+Notes
+- Keep the service stateless where possible; log audit context (who, what paths, base sha).
+

--- a/procedures/site/bump_cora_submodule.md
+++ b/procedures/site/bump_cora_submodule.md
@@ -1,0 +1,32 @@
+---
+kind: procedure
+title: Site — Bump CORA Submodule
+intent: Update a downstream repo’s pinned CORA commit (or track branch) and commit the pointer
+status: active
+updated: 2025-10-04
+tags: [site, git, submodule]
+---
+
+# Procedure — Bump CORA Submodule
+
+Purpose
+- Keep downstream projects in sync with CORA canonical by updating the `cora/` submodule pointer.
+
+Inputs
+- Desired target (branch tip or specific commit SHA)
+
+Steps
+1) From downstream repo root:
+   - Track a branch (optional, one-time): `git submodule set-branch --branch main cora && git add .gitmodules && git commit -m "Track cora main"`
+   - Update to latest tracked branch: `git submodule update --remote cora`
+   - Or pin to a specific SHA: `cd cora && git fetch && git checkout <sha> && cd ..`
+2) Commit the pointer bump:
+   - `git add cora && git commit -m "Bump cora to <short-sha>"`
+3) Open a PR; reference related CORA PRs in the body.
+
+Expected
+- Downstream repo points to the intended CORA commit; PR documents why.
+
+Notes
+- Submodules pin to a commit; updating requires a commit per downstream repo.
+


### PR DESCRIPTION
Summary
- Adds tasks for write-through PR API (design, implement, GUI wiring, webhooks).
- Adds procedures for proposing CORA updates via PR and bumping submodule.

What Changed
- context/project-tasks/coherenceism-project/design-write-through-pr-api.md
- context/project-tasks/coherenceism-project/implement-write-through-pr-api.md
- context/project-tasks/coherenceism-project/wire-gui-actions-to-api.md
- context/project-tasks/coherenceism-project/webhooks-sync-and-conflicts.md
- procedures/api/propose_cora_update_via_pr.md
- procedures/site/bump_cora_submodule.md
- context/projects/coherenceism-project.md

Impact
- Enables a PR-based write-through flow from the GUI while keeping CORA canonical and auditable.

Links
- context/projects/coherenceism-project.md:1