### PR TITLE
Update PR log: mark PR #8 as Merged (coherenceism.project)

### DIFF
--- a/context/projects/coherenceism-project.md
+++ b/context/projects/coherenceism-project.md
@@ -36,7 +36,7 @@ Build a read‑only, UFC‑aware app that visualizes CORA projects, tasks (with 
 ## PRs (Log)
 - Add entries here when opening PRs (date, branch, title, summary, status, link).
 - Add entries here when opening PRs (date, branch, title, summary, status, link).
-- 2025-10-04 — feature/write-through-api-tasks — Add write-through PR API tasks and procedures — Status: PR Open — PR: https://github.com/joshua-lossner/cora/pull/8
+- 2025-10-04 — feature/write-through-api-tasks — Add write-through PR API tasks and procedures — Status: Merged — PR: https://github.com/joshua-lossner/cora/pull/8
 
 ## Notes
 - Downstream path: `~/Projects/coherenceism.project/` (code lives there; this file tracks intent/plan in CORA).


### PR DESCRIPTION
Documentation-only follow-up to mark PR #8 as Merged in coherenceism.project.

Files
- context/projects/coherenceism-project.md

Checks
- Content-only.