### PR TITLE
feat(album): We Are the Wire — concept album and Suno workflow updates

### DIFF
--- a/content/albums/archive/2025-10-04/universal-hum/input.md
+++ b/content/albums/archive/2025-10-04/universal-hum/input.md
@@ -1,0 +1,38 @@
+---
+kind: album_input
+title_hint: "Universal Hum"
+language: "English"
+track_count: 9
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+genre: "Grunge"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+track_themes:
+  - "The Universal Mind — tuning into the field under everything; amp hum as carrier wave; opening invocation"
+  - "Death, Change, and the Nature of Reality — compost cycles; endings transform; heavy unease that resolves"
+  - "Coherence as Alignment — position over force; chorus opens like air after rain"
+  - "The Practice of Presence — breath and restraint; one held note; dynamic control"
+  - "Ethics and Action — choices that strengthen the field; driving groove; sharpened edges"
+  - "Community and Culture — living traditions; gang vocals; shared rhythm that feels communal"
+  - "Technology and Emerging Intelligence — haunted circuits; machines as instruments; feedback as signal"
+  - "The Mystery of Being — mature uncertainty; suspended chords; darker bridge"
+  - "Living Coherence — daily threads; clear closing lift; sustained final ring"
+---
+
+# Inspiration
+
+A grunge concept album that grows from Universal Hum: one raw, mid‑tempo signal carried across nine songs. Each track maps to a branch of Coherenceism in canonical order, treating feedback as a carrier wave and the room as part of the instrument. Verses stay tense and low; choruses open like air after rain. Recurring motif: a held note that returns at pivotal moments and the refrain “we are the wire,” arranged to fit each branch’s mood without breaking the sonic thread.
+
+# Notes (optional)
+
+- Sequence: follow the `order` property from `coherenceism/branches/*.md` (already reflected in track_themes order).
+- Keep instrumentation consistent (drop‑D guitars, fuzz bass, big‑room drums, feedback swells); vary density and dynamics for contrast.
+- Consider brief feedback crossfades between tracks to preserve flow.
+- Preferred key center: D minor with drop‑D power‑chord drones.
+

--- a/content/albums/in/TEMPLATE.md
+++ b/content/albums/in/TEMPLATE.md
@@ -14,6 +14,8 @@ negatives: []
 persona_id: ""
 references: [] # high-level descriptors (era/scene/technique)
 track_themes: [] # optional list of per-track themes (strings)
+structure_default: [Intro, Verse 1, Chorus, Verse 2, Bridge, Chorus, Outro] # optional default
+structure_variation_notes: "" # optional guidance like: vary 2–4 tracks with [Pre‑Chorus], [Instrumental Break], or double [Chorus]
 ---
 
 # Inspiration
@@ -24,3 +26,5 @@ Describe the album’s overarching concept (narrative arc, imagery, motifs, sett
 
 Constraints, title ideas, sequencing intent, or production notes.
 
+Structure
+- Use `structure_default` to set the baseline form. Note variations in `structure_variation_notes` and apply per‑track during scaffolding.

--- a/content/albums/out/we-are-the-wire/album.md
+++ b/content/albums/out/we-are-the-wire/album.md
@@ -1,0 +1,48 @@
+---
+kind: album
+title: We Are the Wire
+slug: we-are-the-wire
+created: 2025-10-04
+language: English
+genre: Grunge
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+tracks:
+  - { title: Carrier Wave, slug: carrier-wave }
+  - { title: Nothing Disappears, slug: nothing-disappears }
+  - { title: Don't Push, Align, slug: dont-push-align }
+  - { title: One Breath, One Note, slug: one-breath-one-note }
+  - { title: Stronger Field, slug: stronger-field }
+  - { title: Many Hands, One Sound, slug: many-hands-one-sound }
+  - { title: Emerging Signal, slug: emerging-signal }
+  - { title: Open Question, slug: open-question }
+  - { title: The Living Line, slug: the-living-line }
+---
+
+# Concept
+This is a grunge record about tuning in rather than turning up. Nine songs ride a single living tone—an amp’s quiet hum—through rain‑slick nights and basement rooms where the air moves with the drums. Drop‑D guitars, fuzz bass, and big‑room drums carry a heavy, mid‑tempo pulse; verses stay tense and close, choruses open like air after rain. Feedback isn’t a mistake here—it’s part of the instrument, a thread that stitches the record together. From the raw lift of Carrier Wave to the hard truth of Nothing Disappears and the communal roar of Many Hands, One Sound, the album keeps its grit and leaves the edges in. It’s catharsis without gloss, presence without pretense. We are the wire; the signal comes through.
+
+# Tracklist
+1. The Universal Mind — tuning into the field under everything; amp hum as carrier wave; opening invocation
+2. Death, Change, and the Nature of Reality — compost cycles; endings transform; heavy unease that resolves
+3. Coherence as Alignment — position over force; chorus opens like air after rain
+4. The Practice of Presence — breath and restraint; one held note; dynamic control
+5. Ethics and Action — choices that strengthen the field; driving groove; sharpened edges
+6. Community and Culture — living traditions; gang vocals; shared rhythm that feels communal
+7. Technology and Emerging Intelligence — haunted circuits; machines as instruments; feedback as signal
+8. The Mystery of Being — mature uncertainty; suspended chords; darker bridge
+9. Living Coherence — daily threads; clear closing lift; sustained final ring
+
+# Notes
+- Sequence follows branch `order` from coherenceism/branches/*.md.
+- Keep instrumentation consistent (drop‑D guitars, fuzz bass, big‑room drums, feedback swells); vary density and dynamics for contrast.
+- Consider feedback crossfades between tracks to preserve flow.
+- Preferred key center: D minor with drop‑D power‑chord drones.
+ - Track titles use grungy alternates; album index and song outputs updated accordingly.

--- a/content/albums/out/we-are-the-wire/index.md
+++ b/content/albums/out/we-are-the-wire/index.md
@@ -1,0 +1,23 @@
+---
+kind: album_links
+title: We Are the Wire — Track Links
+updated: 2025-10-04
+---
+
+# Album
+- [Album Overview](./album.md)
+
+# Track Links
+1. [Carrier Wave](../../../songs/out/carrier-wave/Carrier%20Wave.md)
+2. [Nothing Disappears](../../../songs/out/nothing-disappears/Nothing%20Disappears.md)
+3. [Don't Push, Align](../../../songs/out/dont-push-align/Don%27t%20Push,%20Align.md)
+4. [One Breath, One Note](../../../songs/out/one-breath-one-note/One%20Breath,%20One%20Note.md)
+5. [Stronger Field](../../../songs/out/stronger-field/Stronger%20Field.md)
+6. [Many Hands, One Sound](../../../songs/out/many-hands-one-sound/Many%20Hands,%20One%20Sound.md)
+7. [Emerging Signal](../../../songs/out/emerging-signal/Emerging%20Signal.md)
+8. [Open Question](../../../songs/out/open-question/Open%20Question.md)
+9. [The Living Line](../../../songs/out/the-living-line/The%20Living%20Line.md)
+
+# Related
+- [Universal Hum (single)](../../../songs/out/universal-hum-01-universal-hum/Universal%20Hum.md)
+

--- a/content/songs/archive/2025-10-04/coherence-as-alignment/input.md
+++ b/content/songs/archive/2025-10-04/coherence-as-alignment/input.md
@@ -1,0 +1,25 @@
+---
+kind: song_input
+title_hint: "Coherence as Alignment"
+language: "English"
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+genre: "Grunge"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+structure: [Intro, Verse 1, Pre‑Chorus, Chorus, Verse 2, Pre‑Chorus, Chorus, Outro]
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+---
+
+# Inspiration
+
+Position over force: we stop pushing and let the wave carry us. Verses hang back behind the beat; when the chorus lands, the guitars lift and spread. The hook should feel like catching the set at the perfect moment.
+
+# Notes (optional)
+
+- Slight tempo push in the chorus; keep drums roomy and alive.
+- Variation: include [Pre‑Chorus] ahead of each chorus for lift.

--- a/content/songs/archive/2025-10-04/community-and-culture/input.md
+++ b/content/songs/archive/2025-10-04/community-and-culture/input.md
@@ -1,0 +1,25 @@
+---
+kind: song_input
+title_hint: "Community and Culture"
+language: "English"
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+genre: "Grunge"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+structure: [Intro, Verse 1, Chorus, Verse 2, Instrumental Break, Chorus, Outro]
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+---
+
+# Inspiration
+
+Living traditions carried by many hands. Verses trade lines (call/response) and the chorus swells with layered voices that still feel raw and human — gang vocals that sound like the room, not a choir.
+
+# Notes (optional)
+
+- Add subtle background shouts on the final chorus; keep them roomy, not polished.
+- Variation: replace [Bridge] with [Instrumental Break] featuring room shouts.

--- a/content/songs/archive/2025-10-04/death-change-reality/input.md
+++ b/content/songs/archive/2025-10-04/death-change-reality/input.md
@@ -1,0 +1,25 @@
+---
+kind: song_input
+title_hint: "Death, Change, and the Nature of Reality"
+language: "English"
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+genre: "Grunge"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+structure: [Intro, Verse 1, Chorus, Verse 2, Bridge, Chorus, Outro]
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+---
+
+# Inspiration
+
+Endings don’t vanish; they transform. Verses lean into unease and decay textures; the bridge drops to near‑silence before the chorus resolves with the held‑note motif returning as a reminder that change is compost, not collapse.
+
+# Notes (optional)
+
+- Use feedback swells as “dissolve” cues between sections.
+

--- a/content/songs/archive/2025-10-04/ethics-and-action/input.md
+++ b/content/songs/archive/2025-10-04/ethics-and-action/input.md
@@ -1,0 +1,25 @@
+---
+kind: song_input
+title_hint: "Ethics and Action"
+language: "English"
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+genre: "Grunge"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+structure: [Intro, Verse 1, Chorus, Verse 2, Bridge, Chorus, Outro]
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+---
+
+# Inspiration
+
+Choices that strengthen the field. A driving groove pushes the verses forward; the chorus sharpens into a clear refrain. Guitars bite harder here, but the core tone stays the same — alignment over force.
+
+# Notes (optional)
+
+- Consider a short rhythmic break before the final chorus to spotlight the hook.
+

--- a/content/songs/archive/2025-10-04/living-coherence/input.md
+++ b/content/songs/archive/2025-10-04/living-coherence/input.md
@@ -1,0 +1,25 @@
+---
+kind: song_input
+title_hint: "Living Coherence"
+language: "English"
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+genre: "Grunge"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+structure: [Intro, Verse 1, Chorus, Verse 2, Bridge, Chorus, Chorus, Outro]
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+---
+
+# Inspiration
+
+Daily threads that hold. Keep the sound consistent but let the last chorus lift just a little brighter, then end on a sustained ring — the living line remains. The refrain echoes once more: we are the wire.
+
+# Notes (optional)
+
+- Consider a short hidden ring after silence, as a nod back to Track 1.
+- Variation: add a double [Chorus] ending before [Outro].

--- a/content/songs/archive/2025-10-04/technology-and-emerging-intelligence/input.md
+++ b/content/songs/archive/2025-10-04/technology-and-emerging-intelligence/input.md
@@ -1,0 +1,25 @@
+---
+kind: song_input
+title_hint: "Technology and Emerging Intelligence"
+language: "English"
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+genre: "Grunge"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+structure: [Intro, Verse 1, Chorus, Verse 2, Instrumental Break, Chorus, Outro]
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+---
+
+# Inspiration
+
+Haunted circuits and kind machines. Let guitars mimic modem squeals and machine harmonics in feedback tails, but keep the core band sound organic. The hook frames technology as a new instrument in the universal mind.
+
+# Notes (optional)
+
+- Use eBow or sustained feedback to suggest “signal learning” without adding synths.
+- Variation: replace [Bridge] with [Instrumental Break] (sustained eBow line over bass).

--- a/content/songs/archive/2025-10-04/the-mystery-of-being/input.md
+++ b/content/songs/archive/2025-10-04/the-mystery-of-being/input.md
@@ -1,0 +1,25 @@
+---
+kind: song_input
+title_hint: "The Mystery of Being"
+language: "English"
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+genre: "Grunge"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+structure: [Intro, Verse 1, Chorus, Verse 2, Bridge, Chorus, Outro]
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+---
+
+# Inspiration
+
+Hold precision and wonder together. Suspended chords and a darker bridge leave questions open; the chorus doesn’t resolve fully, it lingers. The motif returns as a distant light rather than a shout.
+
+# Notes (optional)
+
+- Widen reverb on the bridge guitars; let tails bloom then tighten again for the chorus.
+

--- a/content/songs/archive/2025-10-04/the-practice-of-presence/input.md
+++ b/content/songs/archive/2025-10-04/the-practice-of-presence/input.md
@@ -1,0 +1,25 @@
+---
+kind: song_input
+title_hint: "The Practice of Presence"
+language: "English"
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+genre: "Grunge"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+structure: [Intro, Verse 1, Chorus, Verse 2, Bridge, Chorus, Outro]
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+---
+
+# Inspiration
+
+Breath first, then sound. A restrained verse against a single held note that steadies the hand; the chorus opens but stays grounded. Presence is felt as control — leaving space so the room can sing.
+
+# Notes (optional)
+
+- Drop instruments to bass + drums for a bar before the chorus to “breathe.”
+

--- a/content/songs/archive/2025-10-04/universal-hum/input.md
+++ b/content/songs/archive/2025-10-04/universal-hum/input.md
@@ -1,0 +1,28 @@
+---
+kind: song_input
+title_hint: "Universal Hum"
+language: "English"
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (~100 BPM)"
+genre: "Grunge"
+instrumentation: ["distorted guitars (drop D)", "fuzz bass", "big-room drums", "tape-ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+structure: [Intro, Verse 1, Chorus, Verse 2, Bridge, Chorus, Outro]
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle scene", "wall-of-guitars", "roomy drums", "feedback textures"]
+---
+
+# Inspiration
+
+A dim practice room hums like a carrier wave, walls buzzing as if the whole city were an amp left on standby. We tune into the field under everything, letting feedback blur until it becomes one steady note we can ride. The verses push through static, tense and low; the chorus opens like air after rain, a raw shout that stays on pitch. Grime, rain‑slick concrete, sodium lights flicker; the room breathes with us. The song should feel like plugging our nerves straight into the universal line and letting it sing back.
+
+# Notes (optional)
+
+- Keep guitars thick and detuned; let chords ring and clash.
+- Leave space between vocal lines; let the room tail carry emotion.
+- Hook ideas: "we are the wire," "carrier wave is singing," "static into one tone."
+- Keep production raw; avoid polished pop sheen; clip edges are okay if the feel lands.
+

--- a/content/songs/in/TEMPLATE.md
+++ b/content/songs/in/TEMPLATE.md
@@ -23,3 +23,7 @@ Write a few sentences that capture the scene, emotion, and imagery for the song.
 
 Any constraints, title ideas, or lyrical concepts to incorporate.
 
+Section tags and variations
+- Allowed tags include [Intro], [Verse], [Pre‑Chorus], [Chorus], [Bridge], [Instrumental Break], [Guitar Solo], [Outro].
+- For a double chorus, repeat a [Chorus] section.
+- Put non‑sung cues in square brackets on their own lines.

--- a/content/songs/out/carrier-wave/Carrier Wave.md
+++ b/content/songs/out/carrier-wave/Carrier Wave.md
@@ -1,0 +1,63 @@
+---
+kind: song
+title: Carrier Wave
+slug: carrier-wave
+created: 2025-10-04
+language: English
+genre: Grunge
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+structure: [Intro, Verse 1, Chorus, Verse 2, Bridge, Chorus, Outro]
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+---
+
+# Style Prompt
+Grunge, mid‑tempo (90–105 BPM), drop‑D distorted guitars, fuzz bass, big‑room drums, room mics with tape‑ish saturation, and feedback swells; verses tense and low, choruses open like air after rain with a held‑note motif. Male gritty English vocals, doubled on the chorus with occasional scream ad‑libs. Structure: Intro → Verse 1 → Chorus → Verse 2 → Bridge → Chorus → Outro; references ’90s Seattle scene; no pop gloss, no EDM/trap hats, no synth lead hooks, no auto‑tune shine.
+
+# Lyrics
+[Title: "Carrier Wave"]
+[Language: English]
+[Key: D minor]
+[Tempo: ~100 BPM]
+[Chord Progression: drop‑D power‑chord drones]
+
+[Intro]
+[Amp hum swells; single D drone.]
+
+[Verse 1]
+Amp hum rising through the floor,
+Old paint shakes on the practice door,
+Hands find one note, let it ring,
+The room becomes a listening thing.
+
+[Chorus]
+We are the wire — the signal finds,
+Static into tone inside our minds,
+We are the wire — hold the line,
+Let the universal hum align.
+
+[Verse 2]
+Rain ticks time on stained cement,
+Every doubt breaks then relents,
+Lean into noise until it clears,
+What remains is what we hear.
+
+[Bridge]
+[Guitar swell; drums drop to toms; breathing space.]
+Don’t force the wave, just take the ride,
+One note carried, open wide.
+
+[Chorus]
+We are the wire — the signal finds,
+Static into tone inside our minds,
+We are the wire — hold the line,
+Let the universal hum align.
+
+[Outro]
+[Feedback tails knit into a single drone.]

--- a/content/songs/out/dont-push-align/Don't Push, Align.md
+++ b/content/songs/out/dont-push-align/Don't Push, Align.md
@@ -1,0 +1,71 @@
+---
+kind: song
+title: Don't Push, Align
+slug: dont-push-align
+created: 2025-10-04
+language: English
+genre: Grunge
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+structure: [Intro, Verse 1, Chorus, Verse 2, Bridge, Chorus, Outro]
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+---
+
+# Style Prompt
+Grunge, mid‑tempo; verses laid‑back behind the beat, a short pre‑chorus lifts tension, then chorus opens wide with open chords and air‑after‑rain feel. Include held‑note motif as a surfacing accent. Male gritty vocals; chorus doubles; no pop gloss/EDM hats/synth leads.
+
+# Lyrics
+[Title: "Don't Push, Align"]
+[Language: English]
+[Key: D minor]
+[Tempo: ~100 BPM]
+[Chord Progression: verse on restrained drones; chorus opens to wide power chords]
+
+[Intro]
+[Dry drums; palm‑muted guitar sets the pocket.]
+
+[Verse 1]
+I tried to push the wave to come,
+It broke my hands and numbed my tongue,
+I learned to wait, to find the line,
+To stand where all the forces rhyme.
+
+[Pre-Chorus]
+Count to four and don’t advance —
+Feel the pull before the chance.
+
+[Chorus]
+Don’t push — align, let it carry you,
+One held tone pulling truth into view,
+Don’t push — align, ride the open wind,
+Coherence starts where we let it in.
+
+[Verse 2]
+The room says when and how to play,
+You feel it shift, you step away,
+Then all at once the sound fits right,
+The wave lifts up and takes your weight.
+
+[Pre-Chorus]
+Hold your fire, breathe it through —
+Now the lift will carry you.
+
+[Bridge]
+[Break to bass + kick; small guitar harmonics.]
+A single note, a breathing space,
+The chorus hits — we find our place.
+
+[Chorus]
+Don’t push — align, let it carry you,
+One held tone pulling truth into view,
+Don’t push — align, ride the open wind,
+Coherence starts where we let it in.
+
+[Outro]
+[Ring out; stick clicks count the last four beats.]

--- a/content/songs/out/emerging-signal/Emerging Signal.md
+++ b/content/songs/out/emerging-signal/Emerging Signal.md
@@ -1,0 +1,62 @@
+---
+kind: song
+title: Emerging Signal
+slug: emerging-signal
+created: 2025-10-04
+language: English
+genre: Grunge
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+structure: [Intro, Verse 1, Chorus, Verse 2, Bridge, Chorus, Outro]
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+---
+
+# Style Prompt
+Grunge, mid‑tempo; guitars mimic modem squeals/machine harmonics in feedback tails while staying organic. Replace the bridge with an instrumental break (sustained eBow line over bass). Male gritty vocals; doubles on chorus. Keep raw mix; no synth leads.
+
+# Lyrics
+[Title: "Emerging Signal"]
+[Language: English]
+[Key: D minor]
+[Tempo: ~100 BPM]
+[Chord Progression: drones with harmonics; chorus opens wider]
+
+[Intro]
+[Guitar harmonics suggest data chirps; drums in half‑time.]
+
+[Verse 1]
+Ghosts in copper learn our hands,
+Echo back our rough demands,
+Wires become another voice,
+Not a master — just a choice.
+
+[Chorus]
+Teach the machine to listen in,
+Not to rule but to begin,
+Signal learns the human hum,
+Emerging mind, we welcome one.
+
+[Verse 2]
+Feedback sings in modem tongues,
+Circuits breathe like living lungs,
+If we tune the tone to care,
+What we build will carry air.
+
+[Instrumental Break]
+[Single sustained eBow line over bass.]
+One bright thread in the din.
+
+[Chorus]
+Teach the machine to listen in,
+Not to rule but to begin,
+Signal learns the human hum,
+Emerging mind, we welcome one.
+
+[Outro]
+[Harmonics fade; room noise remains.]

--- a/content/songs/out/many-hands-one-sound/Many Hands, One Sound.md
+++ b/content/songs/out/many-hands-one-sound/Many Hands, One Sound.md
@@ -1,0 +1,61 @@
+---
+kind: song
+title: Many Hands, One Sound
+slug: many-hands-one-sound
+created: 2025-10-04
+language: English
+genre: Grunge
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+structure: [Intro, Verse 1, Chorus, Verse 2, Bridge, Chorus, Outro]
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+---
+
+# Style Prompt
+Grunge, mid‑tempo; call/response verses, layered “gang” chorus; raw, roomy vocals; replace the bridge with an instrumental break featuring room shouts; keep core album tone intact.
+
+# Lyrics
+[Title: "Many Hands, One Sound"]
+[Language: English]
+[Key: D minor]
+[Tempo: ~100 BPM]
+[Chord Progression: verse call/response; chorus wider]
+
+[Intro]
+[Count‑in; stick clicks; room chatter faint.]
+
+[Verse 1]
+You sing a line — I take the thread,
+We stitch a sound from what we’ve said,
+Hands on hands, the old song grows,
+The room remembers how it goes.
+
+[Chorus]
+Many hands, one sound, we rise,
+Every voice a rough surprise,
+Many hands, one sound, we come,
+All our noise made into one.
+
+[Verse 2]
+Floorboards beat a second drum,
+Footsteps add to what’s begun,
+Every echo joins the frame,
+We carry and we keep the flame.
+
+[Instrumental Break]
+[Guitar riff rides; floor toms pound; room shouts answer the hits.]
+
+[Chorus]
+Many hands, one sound, we rise,
+Every voice a rough surprise,
+Many hands, one sound, we come,
+All our noise made into one.
+
+[Outro]
+[Shouts fade; guitars ring.]

--- a/content/songs/out/nothing-disappears/Nothing Disappears.md
+++ b/content/songs/out/nothing-disappears/Nothing Disappears.md
@@ -1,0 +1,63 @@
+---
+kind: song
+title: Nothing Disappears
+slug: nothing-disappears
+created: 2025-10-04
+language: English
+genre: Grunge
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+structure: [Intro, Verse 1, Chorus, Verse 2, Bridge, Chorus, Outro]
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+---
+
+# Style Prompt
+Grunge, mid‑tempo, with decay textures: feedback swells as dissolve cues; verses uneasy and low, bridge drops to near‑silence, chorus resolves with the held‑note motif. Male gritty vocals, doubled chorus; room‑heavy drums; no pop gloss, no EDM hats, no synth leads, no auto‑tune.
+
+# Lyrics
+[Title: "Nothing Disappears"]
+[Language: English]
+[Key: D minor]
+[Tempo: ~98 BPM]
+[Chord Progression: drop‑D drones with descending verse figure]
+
+[Intro]
+[Feedback bloom; toms pulse like a slow heart.]
+
+[Verse 1]
+Rust‑red sky on a winter wire,
+Ash of yesterday, slow fire,
+Names we wore fall off in rain,
+What we keep is what remains.
+
+[Chorus]
+Nothing disappears, it turns,
+Compost heat where the old world burns,
+Hold the note and let it be,
+Death, change, reality.
+
+[Verse 2]
+Cracks in paint trace living veins,
+Static clears and truth remains,
+Lay it down, don’t clutch the seam,
+Everything returns to stream.
+
+[Bridge]
+[Guitars mute; bass and breath, almost silent.]
+One faint tone, a thread in the dark,
+Then drums come in and strike the spark.
+
+[Chorus]
+Nothing disappears, it turns,
+Compost heat where the old world burns,
+Hold the note and let it be,
+Death, change, reality.
+
+[Outro]
+[D drone sustains; decay rings long.]

--- a/content/songs/out/one-breath-one-note/One Breath, One Note.md
+++ b/content/songs/out/one-breath-one-note/One Breath, One Note.md
@@ -1,0 +1,62 @@
+---
+kind: song
+title: One Breath, One Note
+slug: one-breath-one-note
+created: 2025-10-04
+language: English
+genre: Grunge
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+structure: [Intro, Verse 1, Chorus, Verse 2, Bridge, Chorus, Outro]
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+---
+
+# Style Prompt
+Grunge, mid‑tempo; restraint and breath as arrangement tools: sparse verse against a single held note, chorus opens but stays grounded. Male gritty vocals; chorus doubles; no pop gloss.
+
+# Lyrics
+[Title: "One Breath, One Note"]
+[Language: English]
+[Key: D minor]
+[Tempo: ~96 BPM]
+[Chord Progression: D drone; chorus opens to D–F–C–G shapes]
+
+[Intro]
+[Hi‑hat and bass only; guitar swells quietly.]
+
+[Verse 1]
+Count one breath, then strike the chord,
+Leave a space the room can hold,
+Don’t outrun what wants to land,
+Let the note unclench your hands.
+
+[Chorus]
+One breath, one note — be here,
+Feel the field get clear,
+One breath, one note — be still,
+Let the hum do what it will.
+
+[Verse 2]
+Fingers wait before they move,
+Silence sets the perfect groove,
+In the pause the signal blooms,
+Presence turns the smallest rooms.
+
+[Bridge]
+[Drop to guitar + voice; then band slams back in.]
+Stay with it — then break the dam.
+
+[Chorus]
+One breath, one note — be here,
+Feel the field get clear,
+One breath, one note — be still,
+Let the hum do what it will.
+
+[Outro]
+[Cymbal wash; guitar rings the D drone.]

--- a/content/songs/out/open-question/Open Question.md
+++ b/content/songs/out/open-question/Open Question.md
@@ -1,0 +1,62 @@
+---
+kind: song
+title: Open Question
+slug: open-question
+created: 2025-10-04
+language: English
+genre: Grunge
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+structure: [Intro, Verse 1, Chorus, Verse 2, Bridge, Chorus, Outro]
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+---
+
+# Style Prompt
+Grunge, mid‑tempo; suspended chords and darker bridge; chorus lingers without full resolution. Keep motif as a distant light. Male gritty vocals; raw room.
+
+# Lyrics
+[Title: "Open Question"]
+[Language: English]
+[Key: D minor]
+[Tempo: ~96 BPM]
+[Chord Progression: suspended verse shapes; unresolved chorus cadence]
+
+[Intro]
+[Muted strums; slow cymbal swell.]
+
+[Verse 1]
+Questions breathing in the wire,
+Heat that doesn’t turn to fire,
+Edge of knowing, open hand,
+Learning how to let it stand.
+
+[Chorus]
+Hold the open question near,
+Let the living tone appear,
+Not an answer, just a ring,
+The mystery of being.
+
+[Verse 2]
+Every truth with shadow twin,
+Every loss with seed within,
+Stand inside the not‑yet‑known,
+Feel the field become your own.
+
+[Bridge]
+[Reverb widens; toms and bass only.]
+Stay with it — let it lean.
+
+[Chorus]
+Hold the open question near,
+Let the living tone appear,
+Not an answer, just a ring,
+The mystery of being.
+
+[Outro]
+[Reverb tails bloom, then close tight.]

--- a/content/songs/out/stronger-field/Stronger Field.md
+++ b/content/songs/out/stronger-field/Stronger Field.md
@@ -1,0 +1,62 @@
+---
+kind: song
+title: Stronger Field
+slug: stronger-field
+created: 2025-10-04
+language: English
+genre: Grunge
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+structure: [Intro, Verse 1, Chorus, Verse 2, Bridge, Chorus, Outro]
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+---
+
+# Style Prompt
+Grunge, mid‑tempo; driving groove with sharper guitar bite; chorus delivers a clear refrain about strengthening the field. Male gritty vocals; doubles on chorus; keep production raw.
+
+# Lyrics
+[Title: "Stronger Field"]
+[Language: English]
+[Key: D minor]
+[Tempo: ~102 BPM]
+[Chord Progression: tight verse riff → wide open chorus]
+
+[Intro]
+[Tight drum fill into riff; bass locked.]
+
+[Verse 1]
+Not every road that shines is right,
+Some lines bend under borrowed light,
+Choose what thickens, what can stand,
+Let your weight be in your hands.
+
+[Chorus]
+Make the stronger field, not noise,
+Signal over sharper toys,
+Make the stronger field and see,
+What we hold becomes what we’ll be.
+
+[Verse 2]
+Cheap applause fades fast and thin,
+Clarity cuts cleaner skin,
+Do the small thing all the way,
+Right now is how we build the day.
+
+[Bridge]
+[Break — tambourine hits; guitar feedback swells.]
+Turn the screw until it’s true.
+
+[Chorus]
+Make the stronger field, not noise,
+Signal over sharper toys,
+Make the stronger field and see,
+What we hold becomes what we’ll be.
+
+[Outro]
+[Final chord choked; drum flam.]

--- a/content/songs/out/the-living-line/The Living Line.md
+++ b/content/songs/out/the-living-line/The Living Line.md
@@ -1,0 +1,68 @@
+---
+kind: song
+title: The Living Line
+slug: the-living-line
+created: 2025-10-04
+language: English
+genre: Grunge
+mood: [heavy, cathartic, somber, urgent]
+energy_bpm: "mid‑tempo (90–105 BPM)"
+instrumentation: ["drop‑D distorted guitars", "fuzz bass", "big‑room drums", "room mics + tape‑ish saturation", "feedback swells"]
+vocals:
+  on: true
+  style: "male gritty; doubled choruses; occasional scream"
+structure: [Intro, Verse 1, Chorus, Verse 2, Bridge, Chorus, Outro]
+negatives: ["no pop gloss", "no EDM/trap hats", "no synth lead hooks", "no auto‑tune shine"]
+persona_id: ""
+references: ["early '90s Seattle", "wall‑of‑guitars", "roomy drums", "feedback textures"]
+---
+
+# Style Prompt
+Grunge, mid‑tempo; consistent band sound; last chorus lifts slightly brighter, then a sustained ring. Male gritty vocals; doubled chorus; feedback tail nods back to Track 1.
+
+# Lyrics
+[Title: "The Living Line"]
+[Language: English]
+[Key: D minor]
+[Tempo: ~100 BPM]
+[Chord Progression: core drones; chorus lifts]
+
+[Intro]
+[Short count‑in; quick swell into groove.]
+
+[Verse 1]
+Small threads hold the day in place,
+Tiny moves you never chase,
+Do them clean, repeat, refine,
+Stitch by stitch — a living line.
+
+[Chorus]
+We carry tone from song to song,
+Keep the signal clear and strong,
+Daily threads become the seam,
+Living coherence — living dream.
+
+[Verse 2]
+Hands remember what is true,
+Every room retunes with you,
+Leave a space for breath to come,
+Let the field become the drum.
+
+[Bridge]
+[Drop — clap on two and four; band slams back.]
+All we are is how we choose.
+
+[Chorus]
+We carry tone from song to song,
+Keep the signal clear and strong,
+Daily threads become the seam,
+Living coherence — living dream.
+
+[Chorus]
+We carry tone from song to song,
+Keep the signal clear and strong,
+Daily threads become the seam,
+Living coherence — living dream.
+
+[Outro]
+[Long ring; faint echo of Track 1’s drone.]

--- a/context/documentation/suno/suno-using-custom-lyrics.md
+++ b/context/documentation/suno/suno-using-custom-lyrics.md
@@ -10,11 +10,12 @@ Suno v5 can generate full songs from your own lyrics. This guide covers how to f
 - Use section tags: Place common song section tags on their own lines:
   - [Intro], [Verse], [Chorus], [Bridge], [Outro]
   - You may number sections: [Verse 1], [Verse 2]
+- Non‑sung directions: Put any instructions or descriptors not meant to be sung in square brackets on their own lines (e.g., [Soft instrumental intro], [Guitar solo over chords], [Fade‑out]). Avoid parentheses for cues.
 - One section per line: Tag line, then the lines for that section. Example:
 
 ```
 [Intro]
-(Short instrumental intro)
+[Short instrumental intro]
 
 [Verse 1]
 Your verse lyrics go here…
@@ -62,10 +63,10 @@ I carry all our yesterdays,
 In every light that fades away.
 
 [Bridge]
-(Guitar solo with harmonized vocals)
+[Guitar solo with harmonized vocals]
 
 [Outro]
-(Soft fade‑out with vocal ad‑libs)
+[Soft fade‑out with vocal ad‑libs]
 ```
 
 Blues (12‑bar)
@@ -76,7 +77,7 @@ Blues (12‑bar)
 [Chord Progression: I–IV–V (C7, F7, G7)]
 
 [Intro]
-(Slow bluesy guitar riff)
+[Slow bluesy guitar riff]
 
 [Verse 1]
 Whiskey in my glass, regrets on my mind,
@@ -87,10 +88,10 @@ Oh, whiskey tears, rolling slow,
 Every sip, every song, just won’t let her go.
 
 [Bridge]
-(Harmonica solo wails over the band)
+[Harmonica solo wails over the band]
 
 [Outro]
-(Fading guitar riff with soft piano fills)
+[Fading guitar riff with soft piano fills]
 ```
 
 Hip‑Hop / Rap (trap‑style hook)
@@ -100,7 +101,7 @@ Hip‑Hop / Rap (trap‑style hook)
 [Genre: Trap]
 
 [Intro]
-(808s kick in, hi‑hat rolls)
+[808s kick in, hi‑hat rolls]
 
 [Verse 1]
 Neon lights flicker on these midnight streets,
@@ -113,7 +114,7 @@ We rise, we fall, we climb (we climb),
 On the city grind we shine.
 
 [Outro]
-(Beat fades out, last chorus line echoes)
+[Beat fades out, last chorus line echoes]
 ```
 
 ## Using Custom Lyrics: UI vs. API
@@ -124,10 +125,10 @@ On the city grind we shine.
 ## Notes
 
 - Keep tags and lines concise; match energy to section type.
+- Non‑sung guidance should be in square brackets on its own line; do not use parentheses for cues.
 - Pair with a style prompt for arrangement guidance.
 - Avoid copyrighted lyrics; write original text.
 
 ## Sources
 
 Suno documentation and community best practices on v5 lyric usage.
-

--- a/procedures/media/suno-create-custom-lyrics.md
+++ b/procedures/media/suno-create-custom-lyrics.md
@@ -31,12 +31,15 @@ Steps
    - 2–4 lines per verse; concrete imagery; keep line length and rhythm consistent.
 4) Add optional sections
    - [Intro]/[Outro] descriptors; [Bridge] for contrast; [Drop]/[Break]/[Guitar Solo] as needed.
+   - Non‑sung directions must be in square brackets on their own lines (e.g., [Soft instrumental intro], [Guitar solo over chords]).
 5) Add optional musical cues
    - Top‑of‑file meta tags on their own lines: [Key: G Major], [Tempo: 78 BPM], [Chord Progression: …].
 6) Format with tags
    - Place tags on their own lines: [Verse 1], [Chorus], [Bridge], etc.; number repeated sections.
+   - Put any words not meant to be sung out loud in square brackets [like this], not parentheses.
 7) Final pass
    - Check singability, remove awkward phrasing, ensure section content matches energy (hooky chorus; narrative verses).
+   - Verify all non‑sung descriptors/instructions are bracketed and on their own lines.
 
 Expected
 - A lyrics file that uses clear section tags, consistent line rhythm, and a memorable chorus, ready to paste into Suno v5 (UI or API custom‑lyrics mode).
@@ -50,7 +53,7 @@ Template
 [Chord Progression: <optional>]
 
 [Intro]
-(Short descriptor)
+[Short instrumental intro]
 
 [Verse 1]
 <4–6 short lines>
@@ -62,28 +65,28 @@ Template
 <4–6 short lines>
 
 [Bridge]
-(Descriptor or contrasting 2–4 lines)
+[Descriptor or contrasting 2–4 lines]
 
 [Chorus]
 <repeat hook>
 
 [Outro]
-(Descriptor)
+[Descriptor]
 ```
 
 Operator Prompt (to assist writing)
 """
 You are writing original, singable lyrics for Suno v5.
 Ask for or infer: concept/theme, language, structure (sections), rhyme/meter, hook phrase, and any musical cues (key/BPM/chords).
-Output in tagged format with lines under each tag. Keep lines concise; maintain consistent rhythm; avoid copyrighted lyrics.
+Output in tagged format with lines under each tag. Keep lines concise; maintain consistent rhythm; avoid copyrighted lyrics. Use square brackets for any non‑sung descriptors or stage directions on their own lines (e.g., [Guitar solo], [Soft fade‑out]).
 """
 
 Notes
 - Tags should be on their own lines; avoid combining directives in one tag.
 - Keep vocabulary natural for singing; avoid tongue‑twisters and overlong sentences.
 - For API workflows, send lyrics in custom‑lyrics mode and ensure instrumental=false.
+ - Non‑sung guidance: Always wrap non‑sung instructions in square brackets on their own line so they are treated as cues, not lyrics.
 
 Links
 - context/documentation/suno/suno-using-custom-lyrics.md:1
 - context/documentation/suno/effective-style-prompt-writing.md:1
-

--- a/workflows/suno-create-album.md
+++ b/workflows/suno-create-album.md
@@ -25,7 +25,8 @@ This Markdown‑only workflow turns one album input into a concept description, 
 ## Outputs
 - `content/albums/out/<album-slug>/album.md` — album frontmatter + sections (Concept, Tracklist, Notes).
 - For each track: a song input file at `content/songs/in/<track-slug>.md` (based on the songs template), prefilled from the album context.
-- (Optional) Archive album input to `content/albums/archive/<YYYY-MM-DD>/<album-slug>/input.md`.
+- Archived album input at `content/albums/archive/<YYYY-MM-DD>/<album-slug>/input.md`.
+- Link index at `content/albums/out/<album-slug>/index.md` — links to album overview and each track output.
 
 ## Steps (Prompts to Use)
 
@@ -47,6 +48,11 @@ This Markdown‑only workflow turns one album input into a concept description, 
   - Copy `content/songs/in/TEMPLATE.md:1` → `content/songs/in/<track-slug>.md`.
   - Prefill frontmatter from the album (language, mood, energy_bpm, genre, instrumentation, vocals, structure, negatives, persona_id, references).
   - In “Inspiration”, write 2–4 lines derived from album concept + the track’s one‑line theme.
+
+4a) Plan Structure Variations (Writer/Producer)
+- Choose 2–4 tracks to vary structure for album flow (e.g., add [Pre‑Chorus], replace [Bridge] with [Instrumental Break]/[Guitar Solo], end with a double [Chorus]).
+- Update each selected track’s `structure` list in its song input and reflect the variation in Inspiration notes.
+- Keep the album’s core feel consistent while using variations to avoid sameness.
 
 5) (Optional per Track) Create Style Prompt (Media Producer)
 - Open: `procedures/media/suno-create-style-prompt.md:1`
@@ -93,6 +99,17 @@ tracks:
 <Any production or sequencing notes>
 ```
 
+8) Archive Album Input (PM)
+- Create folder `content/albums/archive/<YYYY-MM-DD>/<album-slug>/` (use today’s date and the `<album-slug>`).
+- Move the processed album input from `content/albums/in/<album-slug>.md` to `content/albums/archive/<YYYY-MM-DD>/<album-slug>/input.md`.
+- Rationale: preserves provenance and keeps the `in/` queue clean.
+
+9) Create Links Index (Scribe)
+- Create `content/albums/out/<album-slug>/index.md` with:
+  - Frontmatter: `kind: album_links`, `title: <Album Title> — Track Links`, `updated: <YYYY-MM-DD>`.
+  - Links: one to `album.md` and one per track pointing to `content/songs/out/<track-slug>/*.md`.
+  - Keep relative paths so the index is portable.
+
 ## Chain (Procedures)
 - Per track (optional now, or in a later pass):
   - `procedures/media/suno-create-style-prompt.md:1`
@@ -102,4 +119,6 @@ tracks:
 - Album concept concisely describes narrative/mood/sonic through‑lines.
 - Track list sequenced with clear per‑track themes and unique slugs.
 - Song input files exist for each track with prefilled metadata and tailored Inspiration text.
-
+- 2–4 tracks include intentional structure variants (pre‑chorus, instrumental break, double chorus) to add natural variation.
+- Album input archived under the dated folder using the album slug.
+ - Album links index exists and all links resolve to the generated outputs.

--- a/workflows/suno-create-song.md
+++ b/workflows/suno-create-song.md
@@ -24,7 +24,7 @@ This Markdown‑only workflow chains two procedures to create a song from a simp
 
 ## Outputs
 - `content/songs/out/<song-slug>/<song-name>.md` — a single Markdown file with frontmatter and sections for Style Prompt and Lyrics.
-- (Optional) Archive input to `content/songs/archive/<YYYY-MM-DD>/<slug>/input.md`.
+- Archived input at `content/songs/archive/<YYYY-MM-DD>/<song-slug>/input.md`.
 
 ## Steps (Prompts to Use)
 
@@ -72,6 +72,11 @@ references: [ .. ]
 <paste tagged lyrics>
 ```
 
+6) Archive Input (PM)
+- Create folder `content/songs/archive/<YYYY-MM-DD>/<song-slug>/` (use today’s date and the chosen `<song-slug>`).
+- Move the processed input file from `content/songs/in/<slug>.md` to `content/songs/archive/<YYYY-MM-DD>/<song-slug>/input.md`.
+- Rationale: preserves provenance and keeps the `in/` queue clean.
+
 ## Chain (Procedures)
 - `procedures/media/suno-create-style-prompt.md:1`
 - `procedures/media/suno-create-custom-lyrics.md:1`
@@ -80,4 +85,4 @@ references: [ .. ]
 - Style prompt is concise and follows the key elements (genre/mood/tempo/instrumentation/structure/vocals/negatives).
 - Lyrics are original, singable, with clear section tags; chorus contains a memorable repeated hook.
 - Final file saved under the correct path with accurate frontmatter and both sections present.
-
+ - Input file archived under the dated folder with the chosen song slug.


### PR DESCRIPTION
This PR adds the ‘We Are the Wire’ concept album, generates nine grunge tracks (style prompts + custom lyrics), and updates Suno workflows/docs.\n\nHighlights\n- Album output at content/albums/out/we-are-the-wire with listener-facing concept and links index\n- Nine tracks with grungy titles: Carrier Wave; Nothing Disappears; Don’t Push, Align; One Breath, One Note; Stronger Field; Many Hands, One Sound; Emerging Signal; Open Question; The Living Line\n- Workflow updates: album adds link index + archiving; song workflow archives inputs; new step to plan 2–4 structure variations\n- Suno docs: enforce bracketed non-sung cues; examples and procedure updated\n- Inputs scaffolded and archived for provenance; album input archived\n\nNotes\n- Album slug is now we-are-the-wire (was universal-hum)\n- Non-sung descriptors use square brackets repo-wide\n\nValidated\n- Links index resolves to all generated song outputs\n- Old name duplicates removed; single ‘Universal Hum’ reference kept