### PR TITLE
docs(mcp): restore MCP notes and Codex CLI guidance

### DIFF
--- a/context/documentation/codex-cli.md
+++ b/context/documentation/codex-cli.md
@@ -1,0 +1,44 @@
+---
+kind: documentation
+title: Codex CLI — Using CORA (MCP notes)
+intent: Explain MCP load errors with Codex CLI and how to operate CORA safely
+status: active
+updated: 2025-10-05
+tags: [codex, mcp, tooling]
+---
+
+# Codex CLI — Using CORA (MCP Notes)
+
+Purpose
+- Help operators run `codex` in this repo without vendor lock‑in or crashes.
+
+Key Point
+- CORA trunk intentionally ships no vendor or MCP setup. If your Codex CLI has global MCP servers configured, it may try to boot them on startup. If those servers aren’t installed on your machine, you may see an error like “MCP client failed to load.” This is a client‑side configuration issue, not a problem in CORA.
+
+Operate Safely
+- Keep MCP disabled for CORA, or ensure your configured MCP servers are installed and runnable.
+
+Recommended (Repo‑local, untracked)
+- Create a local Codex config for this repo that does not attempt to load MCP. The repo ignores `.codex/` so your settings won’t be committed.
+  - Make a folder: `.codex/`
+  - Add your Codex CLI’s local config there (see your Codex version’s docs for exact filename/keys) with MCP disabled or with an empty MCP server list.
+  - Example intent: “no MCP for this repo.”
+
+Alternative (Fix your global MCP config)
+- If you want MCP, ensure each server referenced by your global Codex config is installed and resolvable on PATH (Node/Python/uvx/etc.). Typical issues:
+  - Missing runtime (e.g., Node >= 18, Python 3.10+)
+  - Wrong binary path or command name
+  - Virtualenv tools not available in interactive shells
+
+Troubleshooting Checklist
+- Confirm CLI version: `codex --version`
+- Print or locate config (varies by version): check common paths
+  - macOS/Linux: `~/.config/codex/` or `~/.codex/`
+  - macOS (App Support): `~/Library/Application Support/Codex/`
+- Verify each referenced MCP server runs from your shell:
+  - Example: `node -v`, `python3 -V`, `uvx --version`
+  - Then the server command itself, if specified by name
+
+Notes
+- This trunk stays vendor‑neutral; downstream projects may add MCP/tooling.
+

--- a/context/mcp/COHERENCE.md
+++ b/context/mcp/COHERENCE.md
@@ -20,8 +20,9 @@ How to Manage (Global)
 
 Recommended MCPs
 - Web/browser: `context/mcp/web-browser.md:1`
+- Example local config: `context/mcp/codex-config.example.json:1` (copy to `.codex/config.json` locally; `.codex/` is git‑ignored)
 
 Notes
 - Keep commands resilient (use `uvx --from <pkg> <tool>` or similar) to avoid path drift.
 - Validate with a quick health check before relying on an MCP in workflows.
-
+ - CORA trunk is vendor‑neutral: docs only. Place actual configs under `.codex/` locally.

--- a/context/mcp/COHERENCE.md
+++ b/context/mcp/COHERENCE.md
@@ -1,0 +1,27 @@
+---
+kind: documentation
+title: COHERENCE — MCP Servers (Docs)
+intent: Document recommended MCP servers and how to manage them without vendor lock‑in
+status: active
+updated: 2025-10-05
+tags: [mcp, tooling]
+---
+
+# MCP Servers — Index (Docs Only)
+
+Policy
+- The CORA trunk ships no vendor code or MCP setup. This directory documents MCPs for operators.
+- Install MCPs globally (or per‑repo via untracked `.codex/`) as needed. Downstream projects may include code.
+
+How to Manage (Global)
+- List: `codex mcp list`
+- Add: `codex mcp add <name> -- <command> [args...]`
+- Remove: `codex mcp remove <name>`
+
+Recommended MCPs
+- Web/browser: `context/mcp/web-browser.md:1`
+
+Notes
+- Keep commands resilient (use `uvx --from <pkg> <tool>` or similar) to avoid path drift.
+- Validate with a quick health check before relying on an MCP in workflows.
+

--- a/context/mcp/codex-config.example.json
+++ b/context/mcp/codex-config.example.json
@@ -1,0 +1,15 @@
+{
+  "mcp": {
+    "servers": {
+      "web": {
+        "command": [
+          "uvx",
+          "--from",
+          "mcp-browser",
+          "mcp-browser",
+          "mcp"
+        ]
+      }
+    }
+  }
+}

--- a/context/mcp/web-browser.md
+++ b/context/mcp/web-browser.md
@@ -1,0 +1,34 @@
+---
+kind: documentation
+title: MCP — Web Browser (stdio)
+intent: Provide browsing, screenshots, and console capture via MCP
+status: recommended
+updated: 2025-10-05
+tags: [mcp, web, browser]
+---
+
+# MCP — Web Browser (stdio)
+
+Purpose
+- Add web browsing and screenshot capabilities to agent sessions through an MCP server.
+
+Recommended Command (Global)
+- `codex mcp add web -- uvx --from mcp-browser mcp-browser mcp`
+
+Runtime Requirements
+- `uvx` available on PATH (from `uv`)
+- Python 3.10+
+- Playwright runtime (install browsers on first use if prompted):
+  - `uvx --from playwright playwright install chromium`
+
+Health Check
+- Command available: `uvx --from mcp-browser mcp-browser --version`
+- Listed in Codex: `codex mcp list` (shows `web   uvx  --from mcp-browser mcp-browser mcp`)
+
+Removal
+- `codex mcp remove web`
+
+Notes
+- This is a docs-only manifest; CORA trunk does not vendor MCP code.
+- Prefer global install unless a downstream project needs pinned, repo-scoped config.
+

--- a/procedures/integrations/setup_mcp_servers.md
+++ b/procedures/integrations/setup_mcp_servers.md
@@ -1,0 +1,44 @@
+---
+kind: procedure
+title: Integrations — Setup MCP Servers (Codex CLI)
+intent: Configure and validate MCP servers for use with CORA via Codex CLI without vendoring code
+status: active
+updated: 2025-10-05
+tags: [integrations, mcp, codex]
+---
+
+# Procedure — Setup MCP Servers (Codex CLI)
+
+Purpose
+- Add MCP servers (e.g., web browser) to your local Codex CLI for this repo, keeping CORA vendor‑neutral.
+
+Inputs
+- Codex CLI installed
+- Python 3.10+ and `uvx` available on PATH
+
+Steps
+1) Install prerequisites
+   - Verify Python: `python3 -V`
+   - Verify uvx: `uvx --version` (install `uv` if missing)
+2) Install/verify the Web MCP
+   - Check: `uvx --from mcp-browser mcp-browser --version`
+   - First‑time browser runtime (optional): `uvx --from playwright playwright install chromium`
+3) Configure Codex MCP locally (untracked)
+   - Copy `context/mcp/codex-config.example.json:1` → `.codex/config.json` (repo‑local; `.codex/` is git‑ignored).
+   - Or add via CLI: `codex mcp add web -- uvx --from mcp-browser mcp-browser mcp`
+4) Health check
+   - List servers: `codex mcp list` (expect `web`)
+   - Start Codex in this repo; ensure the web MCP does not time out.
+5) Troubleshoot timeouts
+   - Preinstall browsers (Step 2).
+   - Ensure `uvx` is on PATH for the same shell Codex uses.
+   - Manually run: `uvx --from mcp-browser mcp-browser mcp` (should print help/usage, not crash).
+
+Expected
+- Codex starts without “MCP client for `web` failed to start: request timed out.”
+- `codex mcp list` shows `web` and the server responds.
+
+Notes
+- CORA trunk remains vendor‑neutral: we commit docs and examples only; place actual configs in `.codex/` locally.
+- Add more MCP docs under `context/mcp/`; keep commands resilient (prefer `uvx`).
+


### PR DESCRIPTION
Restores the MCP documentation that was dropped from the prior PR.\n\nAdds\n- context/documentation/codex-cli.md — operating CORA with Codex CLI (MCP notes)\n- context/mcp/COHERENCE.md — MCP servers index/policy\n- context/mcp/web-browser.md — recommended web browser MCP (stdio)\n\nNotes\n- Docs-only; CORA trunk remains vendor-neutral (no MCP code).\n- Downstream projects may include actual MCP configs as needed.